### PR TITLE
Fix issue #92.

### DIFF
--- a/vcfUtils/vcf2kinship.cpp
+++ b/vcfUtils/vcf2kinship.cpp
@@ -149,7 +149,7 @@ class IBSKinship : public EmpiricalKinship {
     ++n;
     for (size_t i = 0; i < g.size(); ++i) {
       for (size_t j = 0; j <= i; ++j) {
-        if (g[i] >= 0 || g[j] >= 0) {
+        if (g[i] >= 0 && g[j] >= 0) {
           k[i][j] += 2.0 - abs((int)g[i] - (int)g[j]);
           ++count[i][j];
         }

--- a/vcfUtils/vcf2kinship.cpp
+++ b/vcfUtils/vcf2kinship.cpp
@@ -439,7 +439,7 @@ int output(const std::vector<std::string>& famName,
            bool performPCA, const std::string& outPrefix);
 
 #define PROGRAM "vcf2kinship"
-#define VERSION "20170307"
+#define VERSION "20191018"
 void welcome() {
 #ifdef NDEBUG
   fprintf(stdout, "Thank you for using %s (version %s, git tag %s)\n", PROGRAM,


### PR DESCRIPTION
Fixes a kinship calculation issue with VCF files containing missing data for individuals (#92). Now calling `vcf2kinship` with the input file as mentioned in #92 returns expected results:

    ./rvtests/executable/vcf2kinship --inVcf rvtest-oneline.vcf --ibs --maxMiss 0.5 --out rvtest-online

File `rvtest-online.kinship` contains

    FID     IID     X       Y       Z
    X       X       0       0       0
    Y       Y       0       2       1
    Z       Z       0       1       2

Running the same command for the Balding-Nicols method (replacing `--ibs` by `--bn` in the command above) gives the following output:

    FID     IID     X       Y       Z
    X       X       0       0       0
    Y       Y       0       0.666667        -0.666667
    Z       Z       0       -0.666667       0.666667

which has zeroes for those pairs that involve the individual with the missing variant, `X`, in line with the output of the fixed IBS method. From looking at the source code, neither class `BaldingNicolsKinship` nor currently unused class `IBSKinshipImpute` appear to have the issue encountered in class `IBSKinship`, so the fix should be complete and consistent.