### PR TITLE
Fix logger typo for FLAG_siteMACMin.

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -544,7 +544,7 @@ int main(int argc, char** argv) {
   }
   if (FLAG_siteMACMin > 0) {
     ge->setSiteMACMin(FLAG_siteMACMin);
-    logger->info("Set site minimum MAC to %d", FLAG_siteDepthMin);
+    logger->info("Set site minimum MAC to %d", FLAG_siteMACMin);
   }
   if (FLAG_annoType != "") {
     ge->setAnnoType(FLAG_annoType.c_str());


### PR DESCRIPTION
The current logger outputs FLAG_siteDepthMin instead of FLAG_siteMACMin.
Then, I fixed this typo.