### PR TITLE
Update eigen's URL

### DIFF
--- a/third/Makefile
+++ b/third/Makefile
@@ -81,7 +81,7 @@ pcre-8.36.tar.gz:
 
 eigen-3.3.7.tar.bz2:
 	echo "obtain Eigen..."
-	$(call DOWNLOAD_RENAME,http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2,$@)
+	$(call DOWNLOAD_RENAME,https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2,$@)
 
 gsl-1.16.tar.gz:
 	echo "obtain GSL"


### PR DESCRIPTION
Eigen's library repository migrated from bitbucket to gitlab.

http://eigen.tuxfamily.org/index.php?title=News:Eigen_is_now_on_GitLab.com