### PR TITLE
Fix build: Eigen has moved, and vcfUtils Makefile is referencing a file that does not exist

### DIFF
--- a/third/Makefile
+++ b/third/Makefile
@@ -20,9 +20,7 @@ gsl: gsl-1.16.tar.gz
 	-(DIR=`pwd`; cd gsl-1.16; ./configure --prefix="$${DIR}"/gsl; make -j; make install)
 
 eigen: eigen-3.3.7.tar.bz2
-	-rm -rf eigen-eigen*
 	tar jxf eigen-3.3.7.tar.bz2
-	-mv eigen-eigen-* eigen-3.3.7
 	ln -s -f eigen-3.3.7 eigen
 
 zlib: zlib-1.2.8.tar.gz
@@ -81,7 +79,7 @@ pcre-8.36.tar.gz:
 
 eigen-3.3.7.tar.bz2:
 	echo "obtain Eigen..."
-	$(call DOWNLOAD_RENAME,http://bitbucket.org/eigen/eigen/get/3.3.7.tar.bz2,$@)
+	$(call DOWNLOAD_RENAME,https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.bz2,$@)
 
 gsl-1.16.tar.gz:
 	echo "obtain GSL"

--- a/vcfUtils/Makefile
+++ b/vcfUtils/Makefile
@@ -24,7 +24,7 @@ UTIL_EXEC = vcf2plink vcfSummary vcfConcordance \
             createVCFIndex \
             queryVCFIndex \
             extractVCFIndex \
-            createBCF2Index \
+            # createBCF2Index \
             # vcf2merlin 
 
 DIR_EXEC = ../executable


### PR DESCRIPTION
- Update eigen download URL to gitlab
- update paths because tarball structure has changed
- remove reference to file that doesn't exist in vcftools createBCF2Index